### PR TITLE
feat: validate Delivery Response

### DIFF
--- a/src/main/java/ai/promoted/delivery/client/ApiDelivery.java
+++ b/src/main/java/ai/promoted/delivery/client/ApiDelivery.java
@@ -101,11 +101,11 @@ public class ApiDelivery implements Delivery  {
       }
       else {
         resp = processUncompressedResponse(response);
-      }      
+      }
     } catch (Exception ex) {
       throw new DeliveryException("Error running delivery", ex);
     }
-    
+    validate(resp);
     return state.getResponseToReturn(resp);
   }
 
@@ -125,6 +125,13 @@ public class ApiDelivery implements Delivery  {
       is.transferTo(autoCloseOs);
     }
     return mapper.readValue(os.toByteArray(), Response.class);
+  }
+
+  // @VisibleForTesting
+  static void validate(Response response) throws DeliveryException {
+    if (response.getRequestId() == null || response.getRequestId().equals("")) {
+      throw new DeliveryException("Delivery Response should contain a requestId");
+    }
   }
 
   /**

--- a/src/main/java/ai/promoted/delivery/model/Response.java
+++ b/src/main/java/ai/promoted/delivery/model/Response.java
@@ -11,10 +11,17 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 /**
  * Response
  */
-@JsonPropertyOrder({Response.JSON_PROPERTY_INSERTION, Response.JSON_PROPERTY_PAGING_INFO, Response.JSON_PROPERTY_INTROSPECTION_DATA})
+@JsonPropertyOrder({
+  Response.JSON_PROPERTY_REQUEST_ID,
+  Response.JSON_PROPERTY_INSERTION,
+  Response.JSON_PROPERTY_PAGING_INFO,
+  Response.JSON_PROPERTY_INTROSPECTION_DATA})
 public class Response {
+  public static final String JSON_PROPERTY_REQUEST_ID = "requestId";
+  private String requestId;
+
   public static final String JSON_PROPERTY_INSERTION = "insertion";
-  private List<Insertion> insertion = null;
+  private List<Insertion> insertion = new ArrayList<>();
 
   public static final String JSON_PROPERTY_PAGING_INFO = "pagingInfo";
   private PagingInfo pagingInfo;
@@ -24,15 +31,34 @@ public class Response {
 
   public Response() {}
 
+
+  /**
+   * Get request ID
+   * 
+   * @return requestId
+   **/
+  @JsonProperty(JSON_PROPERTY_REQUEST_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+  public String getRequestId() {
+    return requestId;
+  }
+
+  @JsonProperty(JSON_PROPERTY_REQUEST_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setRequestId(String requestId) {
+    this.requestId = requestId;
+  }
+
   public Response insertion(List<Insertion> insertion) {
+    if (insertion == null) {
+      throw new IllegalArgumentException("insertion needs to be non-null");
+    }
     this.insertion = insertion;
     return this;
   }
 
   public Response addInsertionItem(Insertion insertionItem) {
-    if (this.insertion == null) {
-      this.insertion = new ArrayList<>();
-    }
     this.insertion.add(insertionItem);
     return this;
   }
@@ -119,7 +145,8 @@ public class Response {
       return false;
     }
     Response response = (Response) o;
-    return Objects.equals(this.insertion, response.insertion)
+    return Objects.equals(this.requestId, response.requestId)
+        && Objects.equals(this.insertion, response.insertion)
         && Objects.equals(this.pagingInfo, response.pagingInfo)
         && Objects.equals(this.introspectionData, response.introspectionData);
   }
@@ -133,6 +160,7 @@ public class Response {
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class Response {\n");
+    sb.append("    requestId: ").append(toIndentedString(requestId)).append("\n");
     sb.append("    insertion: ").append(toIndentedString(insertion)).append("\n");
     sb.append("    introspectionData: ").append(toIndentedString(introspectionData)).append("\n");
     sb.append("    pagingInfo: ").append(toIndentedString(pagingInfo)).append("\n");

--- a/src/test/java/ai/promoted/delivery/client/ApiDeliveryTest.java
+++ b/src/test/java/ai/promoted/delivery/client/ApiDeliveryTest.java
@@ -1,0 +1,22 @@
+package ai.promoted.delivery.client;
+
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
+import ai.promoted.delivery.model.Request;
+import ai.promoted.delivery.model.Response;
+
+class ApiDeliveryTest {
+
+  @Test
+  void validate() throws DeliveryException {
+    Response response = new Response();
+    response.setRequestId("reqid");
+    ApiDelivery.validate(response);
+  }
+
+  @Test
+  void validate_missingRequestId() {
+    Response response = new Response();
+    assertThrows(DeliveryException.class, () -> ApiDelivery.validate(response));
+  }
+}


### PR DESCRIPTION
Checks for `requestId`.

Also converts an omitted `insertion` field to an empty list.

TESTING=Ran existing unit tests.  Added small unit test.