### PR TITLE
fix: withMetrics*

### DIFF
--- a/src/main/java/ai/promoted/delivery/client/PromotedDeliveryClient.java
+++ b/src/main/java/ai/promoted/delivery/client/PromotedDeliveryClient.java
@@ -472,7 +472,7 @@ public class PromotedDeliveryClient {
      * @return the builder
      */
     public Builder withMetricsEndpoint(String metricsEndpoint) {
-      this.deliveryEndpoint = metricsEndpoint;
+      this.metricsEndpoint = metricsEndpoint;
       return this;
     }
 
@@ -483,7 +483,7 @@ public class PromotedDeliveryClient {
      * @return the builder
      */
     public Builder withMetricsApiKey(String metricsApiKey) {
-      this.deliveryApiKey = metricsApiKey;
+      this.metricsApiKey = metricsApiKey;
       return this;
     }
 


### PR DESCRIPTION
These were overriding delivery flags.

TESTING=ran existing tests.