### PR TITLE
fix: warmup url replacement

### DIFF
--- a/src/main/java/ai/promoted/delivery/client/ApiDelivery.java
+++ b/src/main/java/ai/promoted/delivery/client/ApiDelivery.java
@@ -139,7 +139,7 @@ public class ApiDelivery implements Delivery  {
    * Do warmup.
    */
   private void runWarmup() {
-    String warmupEndpoint = endpoint.replace("/deliver", "/healthz");
+    String warmupEndpoint = replaceSuffix(endpoint, "/deliver", "/healthz");
     for (int i = 0; i < 20; i++) {
       try {
         HttpRequest httpReq = HttpRequest.newBuilder().uri(URI.create(warmupEndpoint))
@@ -150,4 +150,12 @@ public class ApiDelivery implements Delivery  {
       }
     }
   }
+
+  static String replaceSuffix(String original, String target, String replacement) {
+    if (!original.endsWith(target)) {
+       return original;
+    }
+
+    return original.substring(0, original.length() - target.length()) + replacement;
+}
 }

--- a/src/test/java/ai/promoted/delivery/client/ApiDeliveryTest.java
+++ b/src/test/java/ai/promoted/delivery/client/ApiDeliveryTest.java
@@ -19,4 +19,15 @@ class ApiDeliveryTest {
     Response response = new Response();
     assertThrows(DeliveryException.class, () -> ApiDelivery.validate(response));
   }
+
+  @Test
+  void replaceSuffix() {
+    assertEquals("test", ApiDelivery.replaceSuffix("test", "not", "there"));
+    assertEquals("test", ApiDelivery.replaceSuffix("test", "", ""));
+    assertEquals("tess", ApiDelivery.replaceSuffix("test", "t", "s"));
+    assertEquals("take", ApiDelivery.replaceSuffix("test", "est", "ake"));
+    assertEquals("test", ApiDelivery.replaceSuffix("test", "abtest", "actess"));
+    assertEquals("testtake", ApiDelivery.replaceSuffix("testtest", "est", "ake"));
+    assertEquals("http://delivery.example.com/healthz", ApiDelivery.replaceSuffix("http://delivery.example.com/deliver", "/deliver", "/healthz"));
+  }
 }


### PR DESCRIPTION
The string replace code was causing an invalid url.

TESTING=unit tests