### PR TITLE
fix: headers

### DIFF
--- a/src/main/java/ai/promoted/delivery/client/ApiFactory.java
+++ b/src/main/java/ai/promoted/delivery/client/ApiFactory.java
@@ -5,6 +5,6 @@ package ai.promoted.delivery.client;
  */
 public interface ApiFactory {
   Delivery createSdkDelivery();
-  Delivery createApiDelivery(String endpoint, String apiKey, long timeoutMillis, boolean warmup, int maxRequestInsertions);
+  Delivery createApiDelivery(String endpoint, String apiKey, long timeoutMillis, boolean warmup, int maxRequestInsertions, boolean acceptGzip);
   Metrics createApiMetrics(String endpoint, String apiKey, long timeoutMillis);
 }

--- a/src/main/java/ai/promoted/delivery/client/ApiMetrics.java
+++ b/src/main/java/ai/promoted/delivery/client/ApiMetrics.java
@@ -63,6 +63,7 @@ public class ApiMetrics implements Metrics {
       String requestBody = mapper.writeValueAsString(logRequest);
       // TODO: Compression (does metrics accept that?).
       HttpRequest httpReq = HttpRequest.newBuilder().uri(URI.create(endpoint))
+          .header("Content-Type", "application/json")
           .header("x-api-key", apiKey).timeout(timeoutDuration)
           .POST(HttpRequest.BodyPublishers.ofString(requestBody)).build();
 

--- a/src/main/java/ai/promoted/delivery/client/DefaultApiFactory.java
+++ b/src/main/java/ai/promoted/delivery/client/DefaultApiFactory.java
@@ -11,8 +11,8 @@ public class DefaultApiFactory implements ApiFactory {
   }
 
   @Override
-  public Delivery createApiDelivery(String endpoint, String apiKey, long timeoutMillis, boolean warmup, int maxRequestInsertions) {
-    return new ApiDelivery(endpoint, apiKey, timeoutMillis, warmup, maxRequestInsertions);
+  public Delivery createApiDelivery(String endpoint, String apiKey, long timeoutMillis, boolean warmup, int maxRequestInsertions, boolean acceptGzip) {
+    return new ApiDelivery(endpoint, apiKey, timeoutMillis, warmup, maxRequestInsertions, acceptGzip);
   }
 
   @Override

--- a/src/main/java/ai/promoted/delivery/client/PromotedDeliveryClient.java
+++ b/src/main/java/ai/promoted/delivery/client/PromotedDeliveryClient.java
@@ -85,13 +85,14 @@ public class PromotedDeliveryClient {
    * @param shadowTrafficDeliveryRate rate = [0,1] of traffic not otherwise sent to Delivery API sent as shadow traffic
    * @param sampler the sampler to use
    * @param blockingShadowTraffic flag to make shadow traffic a blocking (instead of background) call
+   * @param acceptGzip whether the client accepts gzip
    */
   private PromotedDeliveryClient(String deliveryEndpoint, String deliveryApiKey,
       long deliveryTimeoutMillis, String metricsEndpoint, String metricsApiKey,
       long metricsTimeoutMillis, boolean warmup, Executor executor,
       int maxRequestInsertions, ApplyTreatmentChecker applyTreatmentChecker,
       ApiFactory apiFactory, float shadowTrafficDeliveryRate, Sampler sampler,
-      boolean performChecks, boolean blockingShadowTraffic) {
+      boolean performChecks, boolean blockingShadowTraffic, boolean acceptGzip) {
 
     if (deliveryTimeoutMillis <= 0) {
       deliveryTimeoutMillis = DEFAULT_DELIVERY_TIMEOUT_MILLIS;
@@ -126,7 +127,7 @@ public class PromotedDeliveryClient {
     this.applyTreatmentChecker = applyTreatmentChecker;
     this.sdkDelivery = apiFactory.createSdkDelivery();
     this.apiMetrics = apiFactory.createApiMetrics(metricsEndpoint, metricsApiKey, metricsTimeoutMillis);
-    this.apiDelivery = apiFactory.createApiDelivery(deliveryEndpoint, deliveryApiKey, deliveryTimeoutMillis, warmup, maxRequestInsertions);
+    this.apiDelivery = apiFactory.createApiDelivery(deliveryEndpoint, deliveryApiKey, deliveryTimeoutMillis, warmup, maxRequestInsertions, acceptGzip);
     this.performChecks = performChecks;
     this.blockingShadowTraffic = blockingShadowTraffic;
   }
@@ -427,6 +428,9 @@ public class PromotedDeliveryClient {
     /** The blocking shadow traffic value */
     private boolean blockingShadowTraffic;
 
+    /** The acceptsGzip value. */
+    private boolean acceptGzip = true;
+
     /**
      * Instantiates a new builder.
      */
@@ -598,6 +602,17 @@ public class PromotedDeliveryClient {
     }
 
     /**
+     * Sets accept gzip encoding header.
+     *
+     * @param acceptGzip accepts gzip
+     * @return the builder
+     */
+    public Builder withAcceptGzip(boolean acceptGzip) {
+      this.acceptGzip = acceptGzip;
+      return this;
+    }
+
+    /**
      * Builds the {@link PromotedDeliveryClient}.
      *
      * @return the promoted delivery client
@@ -606,7 +621,7 @@ public class PromotedDeliveryClient {
       return new PromotedDeliveryClient(deliveryEndpoint, deliveryApiKey, deliveryTimeoutMillis,
           metricsEndpoint, metricsApiKey, metricsTimeoutMillis, warmup, executor,
           maxRequestInsertions, applyTreatmentChecker, apiFactory, shadowTrafficDeliveryRate,
-          sampler, performChecks, blockingShadowTraffic);
+          sampler, performChecks, blockingShadowTraffic, acceptGzip);
     }
   }
 }

--- a/src/main/java/ai/promoted/delivery/client/PromotedDeliveryClient.java
+++ b/src/main/java/ai/promoted/delivery/client/PromotedDeliveryClient.java
@@ -602,7 +602,7 @@ public class PromotedDeliveryClient {
     }
 
     /**
-     * Sets accept gzip encoding header.
+     * Sets accept gzip encoding header.  Defauls to true.
      *
      * @param acceptGzip accepts gzip
      * @return the builder

--- a/src/test/java/ai/promoted/delivery/client/TestApiFactory.java
+++ b/src/test/java/ai/promoted/delivery/client/TestApiFactory.java
@@ -22,7 +22,7 @@ public class TestApiFactory implements ApiFactory {
 
   @Override
   public Delivery createApiDelivery(String endpoint, String apiKey, long timeoutMillis,
-      boolean warmup, int maxRequestInsertions) {
+      boolean warmup, int maxRequestInsertions, boolean acceptGzip) {
     return apiDelivery;
   }
 


### PR DESCRIPTION
PRO-5656

- Adds content type header.
- Makes the accept gzip encoding header configurable via a builder option.

TESTING=ran existing unit tests