### PR TITLE
fix: loosen the http status check to work

### DIFF
--- a/src/main/java/ai/promoted/delivery/client/ApiMetrics.java
+++ b/src/main/java/ai/promoted/delivery/client/ApiMetrics.java
@@ -69,7 +69,7 @@ public class ApiMetrics implements Metrics {
 
       HttpResponse<String> response =
           httpClient.send(httpReq, HttpResponse.BodyHandlers.ofString());
-      if (response.statusCode() != 200) {
+      if (response.statusCode() < 200 || 300 <= response.statusCode()) {
         LOGGER.warning(() -> "Failure calling Metrics API; statusCode="  + response.statusCode()
           + ", body=" + response.body());
       }

--- a/src/main/java/ai/promoted/delivery/client/ApiMetrics.java
+++ b/src/main/java/ai/promoted/delivery/client/ApiMetrics.java
@@ -69,7 +69,7 @@ public class ApiMetrics implements Metrics {
 
       HttpResponse<String> response =
           httpClient.send(httpReq, HttpResponse.BodyHandlers.ofString());
-      if (response.statusCode() < 200 || 300 <= response.statusCode()) {
+      if (response.statusCode() < 200 || 300 <= response.statusCode()) {
         LOGGER.warning(() -> "Failure calling Metrics API; statusCode="  + response.statusCode()
           + ", body=" + response.body());
       }


### PR DESCRIPTION
Metrics API logs a 202.  We'll treat any 2xx as a successful call.

TESTING=none