### PR TITLE
refactor: support splitting `deliver`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ hs_err_pid*
 
 .vscode/
 pom.xml.versionsBackup
+.idea

--- a/README.md
+++ b/README.md
@@ -353,7 +353,10 @@ Here's an example using custom arm assignment logic (not using `twoArmExperiment
 
 ## When there is ranking logic after the SDK's `deliver` method.
 
-It is strongly advised against implementing ranking logic after the deliver method. Using this approach may result in suboptimal rankings from Promoted. Furthermore, the Delivery API will not have access to the final position, which can affect the performance of the Blender and third-stage ranking. While asynchronous logging of positions back to Promoted is supported, the join rate is not guaranteed to be 100%. This makes addressing position biases challenging.  Introspection reports will not be accurate.
+It is strongly advised against implementing ranking logic after the deliver method.  Promoted will perform suboptimally and certain production functions will be broken:
+- The Delivery API will not have access to the final position, which can affect the performance of third-stage ranking and the Blender.
+- While asynchronous logging of positions back to Promoted is supported, the join rate is not guaranteed to be 100%. This makes addressing position biases challenging.
+- Introspection reports will not be accurate.
 
 For optimal results with Promoted's SDK, all ranking logic should be done before the `deliver` method.  Here's an example flow in a listing API call:
 1. The Controller retrieves candidates.

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ Here's an example using custom arm assignment logic (not using `twoArmExperiment
 
 ## When there is ranking logic after the SDK's `deliver` method.
 
-Note: It is strongly discouraged to have ranking logic after the `deliver` method.  The results will likely be worse.
+It is strongly advised against implementing ranking logic after the deliver method. Using this approach may result in suboptimal rankings from Promoted. Furthermore, the Delivery API will not have access to the final position, which can affect the performance of the Blender and third-stage ranking. While asynchronous logging of positions back to Promoted is supported, the join rate is not guaranteed to be 100%. This makes addressing position biases challenging.
 
 For optimal results with Promoted's SDK, all ranking logic should be done before the `deliver` method.  Here's an example flow in a listing API call:
 1. The Controller retrieves candidates.

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ Here's an example using custom arm assignment logic (not using `twoArmExperiment
 
 ## When there is ranking logic after the SDK's `deliver` method.
 
-It is strongly advised against implementing ranking logic after the deliver method. Using this approach may result in suboptimal rankings from Promoted. Furthermore, the Delivery API will not have access to the final position, which can affect the performance of the Blender and third-stage ranking. While asynchronous logging of positions back to Promoted is supported, the join rate is not guaranteed to be 100%. This makes addressing position biases challenging.
+It is strongly advised against implementing ranking logic after the deliver method. Using this approach may result in suboptimal rankings from Promoted. Furthermore, the Delivery API will not have access to the final position, which can affect the performance of the Blender and third-stage ranking. While asynchronous logging of positions back to Promoted is supported, the join rate is not guaranteed to be 100%. This makes addressing position biases challenging.  Introspection reports will not be accurate.
 
 For optimal results with Promoted's SDK, all ranking logic should be done before the `deliver` method.  Here's an example flow in a listing API call:
 1. The Controller retrieves candidates.

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<groupId>ai.promoted</groupId>
 	<artifactId>deliveryclient</artifactId>
 	<packaging>jar</packaging>
-	<version>2.0.6</version>
+	<version>2.0.7</version>
 	<name>${project.groupId}:${project.artifactId}</name>
 	<description>A Java Client to contact the Promoted.ai Delivery API.</description>
 	<url>https://github.com/promotedai/promoted-java-delivery-client</url>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<groupId>ai.promoted</groupId>
 	<artifactId>deliveryclient</artifactId>
 	<packaging>jar</packaging>
-	<version>2.0.7</version>
+	<version>2.0.6</version>
 	<name>${project.groupId}:${project.artifactId}</name>
 	<description>A Java Client to contact the Promoted.ai Delivery API.</description>
 	<url>https://github.com/promotedai/promoted-java-delivery-client</url>

--- a/src/main/java/ai/promoted/delivery/client/DefaultDeliveryRequestValidator.java
+++ b/src/main/java/ai/promoted/delivery/client/DefaultDeliveryRequestValidator.java
@@ -15,9 +15,9 @@ public class DefaultDeliveryRequestValidator implements DeliveryRequestValidator
       new DefaultDeliveryRequestValidator();
 
   /**
-   * @see DeliveryRequestValidator#validate(DeliveryRequest, boolean)
+   * @see DeliveryRequestValidator#validate(DeliveryRequest)
    */
-  public List<String> validate(DeliveryRequest request, boolean isShadowTraffic) {
+  public List<String> validate(DeliveryRequest request) {
     List<String> validationErrors = new ArrayList<>();
 
     Request req = request.getRequest();

--- a/src/main/java/ai/promoted/delivery/client/DeliveryPlan.java
+++ b/src/main/java/ai/promoted/delivery/client/DeliveryPlan.java
@@ -1,0 +1,20 @@
+package ai.promoted.delivery.client;
+
+class DeliveryPlan {
+
+  private String clientRequestId;
+  private boolean useApiResponse;
+
+  public DeliveryPlan(String clientRequestId, boolean useApiResponse) {
+    this.clientRequestId = clientRequestId;
+    this.useApiResponse = useApiResponse;
+  }
+
+  public String getClientRequestId() {
+    return clientRequestId;
+  }
+
+  public boolean useApiResponse() {
+    return useApiResponse;
+  }
+}

--- a/src/main/java/ai/promoted/delivery/client/DeliveryPlan.java
+++ b/src/main/java/ai/promoted/delivery/client/DeliveryPlan.java
@@ -1,10 +1,18 @@
 package ai.promoted.delivery.client;
 
+/**
+ * A plan object that can indicates how to execute delivery.
+ */
 class DeliveryPlan {
 
   private String clientRequestId;
   private boolean useApiResponse;
 
+  /**
+   * @param clientRequestId The client's requestId.  Important because the ID should match
+   *                        if both API and SDK Delivery are done.
+   * @param useApiResponse Whether the SDK should attempt to use Delivery API's Response.
+   */
   public DeliveryPlan(String clientRequestId, boolean useApiResponse) {
     this.clientRequestId = clientRequestId;
     this.useApiResponse = useApiResponse;

--- a/src/main/java/ai/promoted/delivery/client/DeliveryPlan.java
+++ b/src/main/java/ai/promoted/delivery/client/DeliveryPlan.java
@@ -1,7 +1,7 @@
 package ai.promoted.delivery.client;
 
 /**
- * A plan object that can indicates how to execute delivery.
+ * A plan object that can indicate how to execute delivery.
  */
 class DeliveryPlan {
 

--- a/src/main/java/ai/promoted/delivery/client/DeliveryRequest.java
+++ b/src/main/java/ai/promoted/delivery/client/DeliveryRequest.java
@@ -123,13 +123,12 @@ public class DeliveryRequest implements Cloneable {
 
   /**
    * Checks the state of this delivery requests and collects/returns any validation errors.
-   * @param isShadowTraffic 
-   * 
+   *
    * @return a list of validation errors, which may be empty.
    */
-  public List<String> validate(boolean isShadowTraffic) {
+  public List<String> validate() {
     if (validator != null ) {
-      return validator.validate(this, isShadowTraffic);
+      return validator.validate(this);
     }    
     return new ArrayList<>();
   }

--- a/src/main/java/ai/promoted/delivery/client/DeliveryRequestValidator.java
+++ b/src/main/java/ai/promoted/delivery/client/DeliveryRequestValidator.java
@@ -9,9 +9,8 @@ public interface DeliveryRequestValidator {
   /**
    * Checks the state of this delivery requests and collects/returns any validation errors.
    * @param request the delivery request to validate 
-   * @param isShadowTraffic whether or not we're in shadow traffic mode, which changes some validation logic
-   * 
+   *
    * @return a list of validation errors, which may be empty.
    */
-  List<String> validate(DeliveryRequest request, boolean isShadowTraffic);
+  List<String> validate(DeliveryRequest request);
 }

--- a/src/main/java/ai/promoted/delivery/client/PromotedDeliveryClient.java
+++ b/src/main/java/ai/promoted/delivery/client/PromotedDeliveryClient.java
@@ -167,7 +167,6 @@ public class PromotedDeliveryClient {
    */
   public DeliveryPlan plan(boolean onlyLog, @Nullable CohortMembership experiment) {
     boolean useApiResponse = !onlyLog && shouldApplyTreatment(experiment);
-    // TODO - why does checkCohortMembership copy?
     return new DeliveryPlan(generateClientRequestId(), useApiResponse);
   }
 

--- a/src/main/java/ai/promoted/delivery/client/PromotedDeliveryClient.java
+++ b/src/main/java/ai/promoted/delivery/client/PromotedDeliveryClient.java
@@ -282,23 +282,13 @@ public class PromotedDeliveryClient {
     return (shadowTrafficDeliveryRate > 0 && sampler.sampleRandom(shadowTrafficDeliveryRate));
   }
   
-  /**
-   * Clone CohortMembership from the request, based on the provided experiment.
-   * If there isn't one, returns null.
-   *
-   * @param deliveryRequest the delivery request
-   * @return the cohort membership to use, or null if none
-   */
-  private CohortMembership cloneCohortMembership(CohortMembership experiment) {
-    if (experiment == null) {
+  private CohortMembership cloneCohortMembership(CohortMembership cohortMembership) {
+    if (cohortMembership == null) {
       return null;
     }
-
-    // Q - why does this copy the record?  I'm guessing this is to strip out other fields.
-    CohortMembership cohortMembership = new CohortMembership()
-        .arm(experiment.getArm())
-        .cohortId(experiment.getCohortId());    
-    return cohortMembership;
+    return new CohortMembership()
+        .arm(cohortMembership.getArm())
+        .cohortId(cohortMembership.getCohortId());
   }
 
   /**

--- a/src/main/java/ai/promoted/delivery/client/PromotedDeliveryClient.java
+++ b/src/main/java/ai/promoted/delivery/client/PromotedDeliveryClient.java
@@ -146,7 +146,7 @@ public class PromotedDeliveryClient {
     Response apiResponse = null;
     if (plan.useApiResponse()) {
       try {
-        apiResponse = apiDelivery.runDelivery(deliveryRequest);
+        apiResponse = callDeliveryAPI(deliveryRequest);
       } catch (DeliveryException ex) {
         LOGGER.log(Level.WARNING, "Error calling Delivery API, falling back", ex);
       }
@@ -189,6 +189,19 @@ public class PromotedDeliveryClient {
     }
     ensureClientRequestId(deliveryRequest.getRequest(), plan.getClientRequestId());
     fillInRequestFields(deliveryRequest.getRequest());
+  }
+
+  /**
+   * Runs a blocking call to Delivery API.
+   *
+   * <p>This method provides support for reusing/overriding parts of
+   * {@link #deliver(DeliveryRequest) }.  Most users should use the {@code deliver} method instead.
+   * </p>
+   *
+   * @see #deliver
+   */
+  public Response callDeliveryAPI(DeliveryRequest deliveryRequest) throws DeliveryException {
+    return apiDelivery.runDelivery(deliveryRequest);
   }
 
   /**

--- a/src/test/java/ai/promoted/delivery/client/DeliveryRequestTest.java
+++ b/src/test/java/ai/promoted/delivery/client/DeliveryRequestTest.java
@@ -15,7 +15,7 @@ class DeliveryRequestTest {
   @Test
   void testRequestMustBeSet() {
      DeliveryRequest req = new DeliveryRequest(null);
-     List<String> errors = req.validate(false);
+     List<String> errors = req.validate();
      assertEquals(1, errors.size());
      assertEquals("Request must be set", errors.get(0));
   }
@@ -27,7 +27,7 @@ class DeliveryRequestTest {
         null,
         false,
         0);
-    List<String> errors = req.validate(false);
+    List<String> errors = req.validate();
     assertEquals(1, errors.size());
     assertEquals("Request.requestId should not be set", errors.get(0));
   }
@@ -39,7 +39,7 @@ class DeliveryRequestTest {
         null,
         false,
         0);
-    List<String> errors = req.validate(false);
+    List<String> errors = req.validate();
     assertEquals(1, errors.size());
     assertEquals("Insertion.insertionId should not be set", errors.get(0));
   }
@@ -51,7 +51,7 @@ class DeliveryRequestTest {
         null,
         false,
         -1);
-    List<String> errors = req.validate(false);
+    List<String> errors = req.validate();
     assertEquals(1, errors.size());
     assertEquals("Insertion start must be greater or equal to 0", errors.get(0));
   }
@@ -63,7 +63,7 @@ class DeliveryRequestTest {
         null,
         false,
         0);
-    List<String> errors = req.validate(false);
+    List<String> errors = req.validate();
     assertEquals(1, errors.size());
     assertEquals("Insertion.contentId should be set", errors.get(0));
   }
@@ -75,7 +75,7 @@ class DeliveryRequestTest {
         null,
         false,
         0);
-    List<String> errors = req.validate(false);
+    List<String> errors = req.validate();
     assertEquals(0, errors.size());
   }
 
@@ -86,7 +86,7 @@ class DeliveryRequestTest {
         new CohortMembership().arm(CohortArm.TREATMENT).cohortId("my cohort"),
         false,
         0);
-    List<String> errors = req.validate(false);
+    List<String> errors = req.validate();
     assertEquals(0, errors.size());
   }
 
@@ -97,7 +97,7 @@ class DeliveryRequestTest {
         null,
         false,
         0);
-    List<String> errors = req.validate(false);
+    List<String> errors = req.validate();
     assertEquals(1, errors.size());
     assertEquals("Request.userInfo should be set", errors.get(0));
   }
@@ -109,7 +109,7 @@ class DeliveryRequestTest {
         new CohortMembership().arm(CohortArm.TREATMENT).cohortId("my cohort"),
         false,
         0);
-    List<String> errors = req.validate(false);
+    List<String> errors = req.validate();
     assertEquals(1, errors.size());
     assertEquals("Request.userInfo.anonUserId should be set", errors.get(0));
   }
@@ -122,7 +122,7 @@ class DeliveryRequestTest {
         new CohortMembership().arm(CohortArm.TREATMENT).cohortId("my cohort"),
         false,
         0);
-    List<String> errors = req.validate(false);
+    List<String> errors = req.validate();
     assertEquals(2, errors.size());
     assertEquals("Request.requestId should not be set", errors.get(0));
     assertEquals("Request.userInfo.anonUserId should be set", errors.get(1));

--- a/src/test/java/ai/promoted/delivery/client/PromotedDeliveryClientTest.java
+++ b/src/test/java/ai/promoted/delivery/client/PromotedDeliveryClientTest.java
@@ -69,7 +69,7 @@ class PromotedDeliveryClientTest {
     DeliveryResponse resp = client.deliver(dreq);
     assertNotNull(resp);
 
-    verify(mockValidator, times(1)).validate(dreq, false);
+    verify(mockValidator, times(1)).validate(dreq);
   }
 
   @Test


### PR DESCRIPTION
PRO-5833

For more advanced use cases, this PR allows separate execution of:
1. The blocking call to Delivery API.
2. Handling SDK Delivery, logging to Metrics API `/log` endpoint and shadow traffic.

see the README for more documentation.

This also removed an unused parameter from `validate`.

TESTING=existing tests