### PR TITLE
feat: add `DeliveryResponse.exception`

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ Field Name | Type | Optional? | Description
 `response` | Response | No | The reponse from Delivery API, which includes the insertions. These are from Delivery API (when `deliver` was called, i.e. we weren't either only-log or part of an experiment) or the input insertions (when the other conditions don't hold).
 `clientRequestId` | String | Yes | Client-generated request id sent to Delivery API and may be useful for logging and debugging. You may fill this in yourself if you have a suitable id, otherwise the SDK will generate one.
 `executionServer` | one of 'API' or 'SDK' | Yes | Indicates if response insertions on a delivery request came from the API or the SDK.
+`exception` | DeliveryException | Yes | Is set to a not-null value if the SDK encounters an exception that it swallows.  The default behavior of the top-level `deliver` method is to try Delivery API and fallback to the SDK ranking if the call fails.  
 
 ---
 

--- a/src/main/java/ai/promoted/delivery/client/DeliveryResponse.java
+++ b/src/main/java/ai/promoted/delivery/client/DeliveryResponse.java
@@ -17,7 +17,7 @@ public class DeliveryResponse {
   /** The execution server which indicates if delivery happened in the SDK or vai Delivery API */
   private final ExecutionServer executionServer;
   
-  /** If an exception was encountered.  Nulable. */
+  /** If an exception was encountered.  Nullable. */
   private final DeliveryException exception;
 
   /**

--- a/src/main/java/ai/promoted/delivery/client/DeliveryResponse.java
+++ b/src/main/java/ai/promoted/delivery/client/DeliveryResponse.java
@@ -17,18 +17,23 @@ public class DeliveryResponse {
   /** The execution server which indicates if delivery happened in the SDK or vai Delivery API */
   private final ExecutionServer executionServer;
   
+  /** If an exception was encountered.  Nulable. */
+  private final DeliveryException exception;
+
   /**
    * Instantiates a new delivery response.
    *
    * @param response the response from Delivery
    * @param clientRequestId the client request id
    * @param executionServer the execution server (SDK or API)
+   * @param exception if an exception was encountered
    */
   public DeliveryResponse(Response response, String clientRequestId,
-      ExecutionServer executionServer) {
+      ExecutionServer executionServer, DeliveryException exception) {
     this.response = response;
     this.clientRequestId = clientRequestId;
     this.executionServer = executionServer;
+    this.exception = exception;
   }
 
   /**
@@ -56,5 +61,14 @@ public class DeliveryResponse {
    */
   public Response getResponse() {
     return response;
+  }
+
+  /**
+   * Gets an exception.
+   * 
+   * @return the exception
+   */
+  public DeliveryException getException() {
+    return exception;
   }
 }

--- a/src/test/java/ai/promoted/delivery/client/PromotedDeliveryClientTest.java
+++ b/src/test/java/ai/promoted/delivery/client/PromotedDeliveryClientTest.java
@@ -1,6 +1,7 @@
 package ai.promoted.delivery.client;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -278,8 +279,8 @@ class PromotedDeliveryClientTest {
     Request.Builder reqBuilder = Request.newBuilder().addAllInsertion(TestUtils.createTestRequestInsertions(10));
     DeliveryRequest dreq = new DeliveryRequest(reqBuilder, null, false, 0);
 
-
-    when(apiFactory.getApiDelivery().runDelivery(any())).thenThrow(DeliveryException.class);
+    DeliveryException exception = new DeliveryException("failed");
+    when(apiFactory.getApiDelivery().runDelivery(any())).thenThrow(exception);
     when(apiFactory.getSdkDelivery().runDelivery(any()))
         .thenReturn(Response.newBuilder().addAllInsertion(reqBuilder.getInsertionList()).build());
 
@@ -295,7 +296,7 @@ class PromotedDeliveryClientTest {
     LogRequest logRequest = logRequestCaptor.getValue();
 
     assertSDKLogRequest(reqBuilder, resp.getResponse(), logRequest);
-    assertDeliveryResponse(resp, ExecutionServer.SDK);
+    assertDeliveryResponse(resp, ExecutionServer.SDK, exception);
   }
 
   @Test
@@ -344,7 +345,12 @@ class PromotedDeliveryClientTest {
   }
 
   private void assertDeliveryResponse(DeliveryResponse resp, ExecutionServer sdk) {
+    assertDeliveryResponse(resp, sdk, null);
+  }
+
+  private void assertDeliveryResponse(DeliveryResponse resp, ExecutionServer sdk, DeliveryException e) {
     assertEquals(sdk, resp.getExecutionServer());
     assertTrue(resp.getClientRequestId().length() > 0);
+    assertEquals(e, resp.getException());
   }
 }


### PR DESCRIPTION
PRO-7302

Some clients might want to measure and monitor the exception field directly instead of relying on a text logger solution.

TESTING=modified unit tests